### PR TITLE
Add transaction builder support for POST/PUT flows

### DIFF
--- a/src/client/HttpClient.ts
+++ b/src/client/HttpClient.ts
@@ -310,10 +310,13 @@ export class HttpClient {
             );
 
             if (
-               body &&
+               body !== undefined &&
+               body !== null &&
                (method === 'POST' || method === 'PUT') &&
                !hasExplicitContentType
             ) {
+               // String bodies are assumed to be XML (Yahoo Fantasy API write operations
+               // use XML payloads). Pass an explicit Content-Type header to override.
                requestHeaders['Content-Type'] =
                   typeof body === 'string'
                      ? 'application/xml'

--- a/src/client/HttpClient.ts
+++ b/src/client/HttpClient.ts
@@ -224,7 +224,7 @@ export class HttpClient {
     */
    async post<T = unknown>(
       path: string,
-      body?: Record<string, unknown>,
+      body?: Record<string, unknown> | string,
       options?: RequestOptions,
    ): Promise<T> {
       return this.request<T>(path, { ...options, method: 'POST', body });
@@ -247,7 +247,7 @@ export class HttpClient {
     */
    async put<T = unknown>(
       path: string,
-      body?: Record<string, unknown>,
+      body?: Record<string, unknown> | string,
       options?: RequestOptions,
    ): Promise<T> {
       return this.request<T>(path, { ...options, method: 'PUT', body });

--- a/src/client/HttpClient.ts
+++ b/src/client/HttpClient.ts
@@ -302,9 +302,23 @@ export class HttpClient {
 
             // Build headers
             const requestHeaders: Record<string, string> = {
-               'Content-Type': 'application/json',
                ...headers,
             };
+
+            const hasExplicitContentType = Object.keys(headers).some(
+               (key) => key.toLowerCase() === 'content-type',
+            );
+
+            if (
+               body &&
+               (method === 'POST' || method === 'PUT') &&
+               !hasExplicitContentType
+            ) {
+               requestHeaders['Content-Type'] =
+                  typeof body === 'string'
+                     ? 'application/xml'
+                     : 'application/json';
+            }
 
             // Add OAuth authorization if not skipped
             if (!skipAuth) {

--- a/src/request/builder.ts
+++ b/src/request/builder.ts
@@ -7,6 +7,7 @@
  */
 
 import type { HttpClient } from '../client/HttpClient.js';
+import type { RequestOptions } from '../client/HttpClient.js';
 import type { InferResponseType } from '../types/request/context.js';
 import type {
    GameKey,
@@ -14,6 +15,7 @@ import type {
    LeagueKey,
    PlayerKey,
    TeamKey,
+   TransactionKey,
 } from '../types/request/graph.js';
 import type {
    PlayerStatusParam,
@@ -42,6 +44,7 @@ type GamePath = ['game', GameKey];
 type LeaguePath = ['league', LeagueKey];
 type TeamPath = ['team', TeamKey];
 type PlayerPath = ['player', PlayerKey];
+type TransactionPath = ['transaction', TransactionKey];
 type UsersPath = ['users'];
 type UsersGamesPath = [...UsersPath, 'games'];
 type TeamRosterPath = [...TeamPath, 'roster'];
@@ -82,6 +85,12 @@ type PlayerScopedParamMethodNames =
    | 'status'
    | 'sort'
    | 'search';
+type TransactionsCollectionParamMethodNames =
+   | 'type'
+   | 'types'
+   | 'teamKey'
+   | 'count'
+   | 'start';
 type DateScopedParamMethodNames = 'week' | 'date';
 type UserScopedParamMethodNames = 'useLogin';
 type RootNavigationMethodNames =
@@ -89,6 +98,7 @@ type RootNavigationMethodNames =
    | 'league'
    | 'team'
    | 'player'
+   | 'transaction'
    | 'users'
    | 'games';
 type GameNavigationMethodNames =
@@ -152,6 +162,9 @@ type TeamRosterStageMethodNames =
    | SharedMethodNames
    | TeamRosterNavigationMethodNames
    | DateScopedParamMethodNames;
+type TransactionsCollectionStageMethodNames =
+   | SharedMethodNames
+   | TransactionsCollectionParamMethodNames;
 type PlayersCollectionStageMethodNames =
    | SharedMethodNames
    | PlayerScopedParamMethodNames
@@ -163,6 +176,7 @@ type TeamsCollectionStageMethodNames =
 type LeaguesCollectionStageMethodNames =
    | SharedMethodNames
    | LeagueScopedParamMethodNames;
+type WriteRequestOptions = Omit<RequestOptions, 'method' | 'body'>;
 
 type PlayerCollectionParamKey =
    | 'player_keys'
@@ -302,6 +316,13 @@ export class RequestBuilder<TPath extends string[] = RootPath> {
    ): Pick<RequestBuilder<PlayerPath>, PlayerStageMethodNames> {
       this.addSegment('resource', 'player', key);
       return this.asStage<PlayerPath, PlayerStageMethodNames>();
+   }
+
+   transaction(
+      key: TransactionKey,
+   ): Pick<RequestBuilder<TransactionPath>, SharedMethodNames> {
+      this.addSegment('resource', 'transaction', key);
+      return this.asStage<TransactionPath>();
    }
 
    users(): Pick<RequestBuilder<UsersPath>, UsersStageMethodNames> {
@@ -503,10 +524,13 @@ export class RequestBuilder<TPath extends string[] = RootPath> {
 
    transactions(): Pick<
       RequestBuilder<[...LeaguePath, 'transactions']>,
-      SharedMethodNames
+      TransactionsCollectionStageMethodNames
    > {
       this.addSegment('collection', 'transactions');
-      return this.asStage<[...LeaguePath, 'transactions']>();
+      return this.asStage<
+         [...LeaguePath, 'transactions'],
+         TransactionsCollectionStageMethodNames
+      >();
    }
 
    drafts(): Pick<
@@ -565,6 +589,15 @@ export class RequestBuilder<TPath extends string[] = RootPath> {
    }
    status(status: PlayerStatusParam | string): this {
       return this.setParam('status', status);
+   }
+   type(transactionType: string): this {
+      return this.setParam('type', transactionType);
+   }
+   types(transactionTypes: string | string[]): this {
+      return this.setParam('types', transactionTypes);
+   }
+   teamKey(key: string): this {
+      return this.setParam('team_key', key);
    }
    sort(sort: SortParam | string): this {
       return this.setParam('sort', sort);
@@ -643,18 +676,24 @@ export class RequestBuilder<TPath extends string[] = RootPath> {
       T = InferResponseType<TPath> extends never
          ? AllResponseTypes
          : InferResponseType<TPath>,
-   >(data?: Record<string, unknown>): Promise<T> {
+   >(
+      data?: Record<string, unknown> | string,
+      options?: WriteRequestOptions,
+   ): Promise<T> {
       const path = this.buildPath();
-      return this.httpClient.post<T>(path, data);
+      return this.httpClient.post<T>(path, data, options);
    }
 
    async put<
       T = InferResponseType<TPath> extends never
          ? AllResponseTypes
          : InferResponseType<TPath>,
-   >(data?: Record<string, unknown>): Promise<T> {
+   >(
+      data?: Record<string, unknown> | string,
+      options?: WriteRequestOptions,
+   ): Promise<T> {
       const path = this.buildPath();
-      return this.httpClient.put<T>(path, data);
+      return this.httpClient.put<T>(path, data, options);
    }
 
    async delete<

--- a/src/request/builder.ts
+++ b/src/request/builder.ts
@@ -12,9 +12,11 @@ import type {
    GameKey,
    GetSubResources,
    LeagueKey,
+   PendingTradeKey,
    PlayerKey,
    TeamKey,
    TransactionKey,
+   WaiverClaimKey,
 } from '../types/request/graph.js';
 import type {
    PlayerStatusParam,
@@ -43,7 +45,10 @@ type GamePath = ['game', GameKey];
 type LeaguePath = ['league', LeagueKey];
 type TeamPath = ['team', TeamKey];
 type PlayerPath = ['player', PlayerKey];
-type TransactionPath = ['transaction', TransactionKey];
+type TransactionPath = [
+   'transaction',
+   TransactionKey | WaiverClaimKey | PendingTradeKey,
+];
 type UsersPath = ['users'];
 type UsersGamesPath = [...UsersPath, 'games'];
 type TeamRosterPath = [...TeamPath, 'roster'];
@@ -84,12 +89,7 @@ type PlayerScopedParamMethodNames =
    | 'status'
    | 'sort'
    | 'search';
-type TransactionsCollectionParamMethodNames =
-   | 'type'
-   | 'types'
-   | 'teamKey'
-   | 'count'
-   | 'start';
+type TransactionsCollectionParamMethodNames = 'type' | 'types' | 'teamKey';
 type DateScopedParamMethodNames = 'week' | 'date';
 type UserScopedParamMethodNames = 'useLogin';
 type RootNavigationMethodNames =
@@ -163,6 +163,7 @@ type TeamRosterStageMethodNames =
    | DateScopedParamMethodNames;
 type TransactionsCollectionStageMethodNames =
    | SharedMethodNames
+   | PaginationParamMethodNames
    | TransactionsCollectionParamMethodNames;
 type PlayersCollectionStageMethodNames =
    | SharedMethodNames
@@ -318,7 +319,7 @@ export class RequestBuilder<TPath extends string[] = RootPath> {
    }
 
    transaction(
-      key: TransactionKey,
+      key: TransactionKey | WaiverClaimKey | PendingTradeKey,
    ): Pick<RequestBuilder<TransactionPath>, SharedMethodNames> {
       this.addSegment('resource', 'transaction', key);
       return this.asStage<TransactionPath>();

--- a/src/request/builder.ts
+++ b/src/request/builder.ts
@@ -6,8 +6,7 @@
  * @module
  */
 
-import type { HttpClient } from '../client/HttpClient.js';
-import type { RequestOptions } from '../client/HttpClient.js';
+import type { HttpClient, RequestOptions } from '../client/HttpClient.js';
 import type { InferResponseType } from '../types/request/context.js';
 import type {
    GameKey,
@@ -590,13 +589,13 @@ export class RequestBuilder<TPath extends string[] = RootPath> {
    status(status: PlayerStatusParam | string): this {
       return this.setParam('status', status);
    }
-   type(transactionType: string): this {
-      return this.setParam('type', transactionType);
+   type(value: string): this {
+      return this.setParam('type', value);
    }
-   types(transactionTypes: string | string[]): this {
-      return this.setParam('types', transactionTypes);
+   types(values: string | string[]): this {
+      return this.setParam('types', values);
    }
-   teamKey(key: string): this {
+   teamKey(key: TeamKey): this {
       return this.setParam('team_key', key);
    }
    sort(sort: SortParam | string): this {

--- a/src/types/request/graph.ts
+++ b/src/types/request/graph.ts
@@ -197,7 +197,7 @@ export interface TransactionResourceDef {
    key: TransactionKey;
    collections: [];
    subResources: [];
-   params: ['types', 'team_key', 'count', 'start'];
+   params: [];
    responseType: TransactionResponse;
 }
 

--- a/src/types/request/graph.ts
+++ b/src/types/request/graph.ts
@@ -27,14 +27,16 @@ export type GameKey = string;
 export type LeagueKey = `${number}.l.${number}` | (string & {});
 export type TeamKey = `${number}.l.${number}.t.${number}` | (string & {});
 export type PlayerKey = `${number}.p.${number}` | (string & {});
-export type TransactionKey =
-   | `${number}.l.${number}.tr.${number}`
-   | (string & {});
 export type WaiverClaimKey =
    | `${number}.l.${number}.w.c.${number}`
    | (string & {});
 export type PendingTradeKey =
    | `${number}.l.${number}.pt.${number}`
+   | (string & {});
+export type TransactionKey =
+   | `${number}.l.${number}.tr.${number}`
+   | WaiverClaimKey
+   | PendingTradeKey
    | (string & {});
 
 /**

--- a/tests/unit/client/HttpClient.test.ts
+++ b/tests/unit/client/HttpClient.test.ts
@@ -311,6 +311,42 @@ describe('HttpClient', () => {
          const [, options] = callArgs;
          expect(options.method).toBe('POST');
          expect(options.body).toBe(JSON.stringify(requestBody));
+         expect(options.headers['Content-Type']).toBe(
+            'application/json',
+         );
+      });
+
+      test('should default string POST bodies to XML content type', async () => {
+         const xmlBody =
+            '<?xml version="1.0"?><fantasy_content><transaction /></fantasy_content>';
+         const fetchMock = mock(() =>
+            Promise.resolve({
+               ok: true,
+               status: 200,
+               text: () =>
+                  Promise.resolve(
+                     '<?xml version="1.0"?><fantasy_content><result>ok</result></fantasy_content>',
+                  ),
+            }),
+         );
+         global.fetch = fetchMock as any;
+
+         const client = new HttpClient(
+            oauth2Client,
+            createTokenProvider(tokens),
+         );
+         await client.post('/test/path', xmlBody);
+
+         const calls = fetchMock.mock.calls;
+         if (!calls || calls.length === 0) {
+            throw new Error('Expected fetch to be called');
+         }
+         const callArgs = calls[0] as any[];
+         const [, options] = callArgs;
+         expect(options.body).toBe(xmlBody);
+         expect(options.headers['Content-Type']).toBe(
+            'application/xml',
+         );
       });
    });
 
@@ -376,6 +412,7 @@ describe('HttpClient', () => {
          const callArgs = calls[0] as any[];
          const [, options] = callArgs;
          expect(options.method).toBe('DELETE');
+         expect(options.headers['Content-Type']).toBeUndefined();
       });
    });
 
@@ -887,9 +924,7 @@ describe('HttpClient', () => {
             oauth2Client,
             createTokenProvider(tokens),
          );
-         await client.post('/test/path', {
-            body: 'raw-string-body',
-         } as any);
+         await client.post('/test/path', 'raw-string-body');
 
          const calls = fetchMock.mock.calls;
          if (!calls || calls.length === 0) {
@@ -898,6 +933,39 @@ describe('HttpClient', () => {
          const callArgs = calls[0] as any[];
          const [, options] = callArgs;
          expect(typeof options.body).toBe('string');
+         expect(options.headers['Content-Type']).toBe(
+            'application/xml',
+         );
+      });
+
+      test('should respect explicit content type for string bodies', async () => {
+         const fetchMock = mock(() =>
+            Promise.resolve({
+               ok: true,
+               status: 200,
+               text: () =>
+                  Promise.resolve(
+                     '<?xml version="1.0"?><fantasy_content><result>ok</result></fantasy_content>',
+                  ),
+            }),
+         );
+         global.fetch = fetchMock as any;
+
+         const client = new HttpClient(
+            oauth2Client,
+            createTokenProvider(tokens),
+         );
+         await client.post('/test/path', '<xml />', {
+            headers: { 'Content-Type': 'text/plain' },
+         });
+
+         const calls = fetchMock.mock.calls;
+         if (!calls || calls.length === 0) {
+            throw new Error('Expected fetch to be called');
+         }
+         const callArgs = calls[0] as any[];
+         const [, options] = callArgs;
+         expect(options.headers['Content-Type']).toBe('text/plain');
       });
    });
 

--- a/tests/unit/client/HttpClient.test.ts
+++ b/tests/unit/client/HttpClient.test.ts
@@ -311,9 +311,7 @@ describe('HttpClient', () => {
          const [, options] = callArgs;
          expect(options.method).toBe('POST');
          expect(options.body).toBe(JSON.stringify(requestBody));
-         expect(options.headers['Content-Type']).toBe(
-            'application/json',
-         );
+         expect(options.headers['Content-Type']).toBe('application/json');
       });
 
       test('should default string POST bodies to XML content type', async () => {
@@ -344,9 +342,7 @@ describe('HttpClient', () => {
          const callArgs = calls[0] as any[];
          const [, options] = callArgs;
          expect(options.body).toBe(xmlBody);
-         expect(options.headers['Content-Type']).toBe(
-            'application/xml',
-         );
+         expect(options.headers['Content-Type']).toBe('application/xml');
       });
    });
 
@@ -933,9 +929,7 @@ describe('HttpClient', () => {
          const callArgs = calls[0] as any[];
          const [, options] = callArgs;
          expect(typeof options.body).toBe('string');
-         expect(options.headers['Content-Type']).toBe(
-            'application/xml',
-         );
+         expect(options.headers['Content-Type']).toBe('application/xml');
       });
 
       test('should respect explicit content type for string bodies', async () => {

--- a/tests/unit/request-builder.test.ts
+++ b/tests/unit/request-builder.test.ts
@@ -115,6 +115,14 @@ describe('RequestBuilder', () => {
          expect(path).toBe('/users');
       });
 
+      it('builds a transaction resource path', () => {
+         const path = createRequest(createMockHttpClient())
+            .transaction('257.l.193.pt.1')
+            .buildPath();
+
+         expect(path).toBe('/transaction/257.l.193.pt.1');
+      });
+
       it('builds a root games collection path', () => {
          const path = createRequest(createMockHttpClient())
             .games()
@@ -224,6 +232,22 @@ describe('RequestBuilder', () => {
 
          expect(path).toBe('/league/423.l.12345/teams;team_keys=t.1,t.2');
       });
+
+      it('supports transaction collection filter helpers', () => {
+         const path = createRequest(createMockHttpClient())
+            .league('423.l.12345')
+            .transactions()
+            .teamKey('423.l.12345.t.1')
+            .type('waiver')
+            .types(['add', 'trade'])
+            .count(5)
+            .start(10)
+            .buildPath();
+
+         expect(path).toBe(
+            '/league/423.l.12345/transactions;team_key=423.l.12345.t.1;type=waiver;types=add,trade;count=5;start=10',
+         );
+      });
    });
 
    describe('execution helpers', () => {
@@ -258,6 +282,54 @@ describe('RequestBuilder', () => {
          expect(httpClient.post).toHaveBeenCalledWith(
             '/league/423.l.12345/transactions',
             payload,
+            undefined,
+         );
+      });
+
+      it('executes POST requests with XML body and options', async () => {
+         const httpClient = createMockHttpClient();
+         const payload =
+            "<?xml version='1.0'?><fantasy_content><transaction><type>pending_trade</type></transaction></fantasy_content>";
+         const options = {
+            headers: { 'Content-Type': 'application/xml' },
+         };
+
+         await createRequest(httpClient)
+            .league('423.l.12345')
+            .transactions()
+            .post(payload, options);
+
+         expect(httpClient.post).toHaveBeenCalledWith(
+            '/league/423.l.12345/transactions',
+            payload,
+            options,
+         );
+      });
+
+      it('executes PUT requests against a transaction resource', async () => {
+         const httpClient = createMockHttpClient();
+         const payload = { transaction: { action: 'accept' } };
+
+         await createRequest(httpClient)
+            .transaction('257.l.193.pt.1')
+            .put(payload);
+
+         expect(httpClient.put).toHaveBeenCalledWith(
+            '/transaction/257.l.193.pt.1',
+            payload,
+            undefined,
+         );
+      });
+
+      it('executes DELETE requests against a transaction resource', async () => {
+         const httpClient = createMockHttpClient();
+
+         await createRequest(httpClient)
+            .transaction('257.l.193.w.c.2_6390')
+            .delete();
+
+         expect(httpClient.delete).toHaveBeenCalledWith(
+            '/transaction/257.l.193.w.c.2_6390',
          );
       });
    });


### PR DESCRIPTION
## Summary\n- add root transaction(key) entrypoint for /transaction/{key}\n- add typed league transactions filter helpers (type/types/teamKey/count/start)\n- allow XML string payloads and options passthrough in RequestBuilder post/put\n- widen HttpClient post/put signatures for string payloads\n- add request builder unit tests for new transaction path/filter/write behavior\n\n## Validation\n- npm test (pass)\n- npm run type-check (fails due to pre-existing unrelated integration/example typing errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction resource with filtering via type, types, and teamKey; new transaction entry points.

* **Behavior Change**
  * POST/PUT now accept string bodies; Content-Type is set only when a body exists (string → application/xml, otherwise application/json) and preserves any explicitly provided Content-Type.

* **Types**
  * Expanded transaction key formats to include additional transaction-like key shapes.

* **Tests**
  * Added unit tests for transaction paths, collection filters, and POST/PUT/DELETE header/body behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->